### PR TITLE
NCIATWP-10397: Force patched Pillow (osv-scanner pip critical)

### DIFF
--- a/extraction-service/requirements.txt
+++ b/extraction-service/requirements.txt
@@ -6,3 +6,12 @@ sigProfilerPlotting==1.2.2
 pandas==1.3.5
 numpy==1.26.4
 PyPDF2==2.11.2
+
+# Security: force a patched Pillow (transitive via the SigProfiler stack).
+# >=12.2.0 clears the critical (PYSEC-2026-457) and all current Pillow highs
+# (GHSA-cfh3/pwv6/whj4). NOTE: Pillow 12 is two majors ahead of the pinned
+# scientific stack (numpy 1.26 / pandas 1.3.5 / sigProfilerPlotting 1.2.2) —
+# the Docker build MUST confirm the SigProfiler packages still resolve/run;
+# if they cap Pillow, fall back to the highest compatible >=10.3.0.
+# torch 2.9.1 retains a no-fix advisory (PYSEC-2026-139) — no patched release.
+Pillow>=12.2.0


### PR DESCRIPTION
## Follow-up to the Dependabot pass (#93), from a full osv-scanner cross-ecosystem scan

Dependabot's npm-focused alerts missed the **pip** dependency tree. `osv-scanner` (which resolves `requirements.txt`) found **Pillow 9.5.0** pulled transitively via the SigProfiler stack with a **critical** (PYSEC-2026-457, 9.3) plus highs.

- Pinned `Pillow>=12.2.0` in `extraction-service/requirements.txt` → clears the critical and all current Pillow highs (verified with osv-scanner: 0 critical / 0 Pillow high).

## ⚠️ CI must validate
Pillow 12 is two majors ahead of the pinned scientific stack (numpy 1.26 / pandas 1.3.5 / sigProfilerPlotting 1.2.2). The Docker build must confirm the SigProfiler packages still resolve and run; if they cap Pillow, fall back to the highest compatible `>=10.3.0` (still clears the critical). I couldn't run the full scientific install locally.

## Residual (no clean fix)
`torch` 2.9.1 PYSEC-2026-139 (high) — no patched release exists.