### PR TITLE
NCIATWP-10865: Fix S3-to-EFS sync permission failure

### DIFF
--- a/.github/aws/sync.yml
+++ b/.github/aws/sync.yml
@@ -10,18 +10,24 @@ volumes:
   - name: data
     efsVolumeConfiguration:
       fileSystemId: "${EFS_FILESYSTEM_ID}"
-      authorizationConfig:
-        accessPointId: "${EFS_ACCESS_POINT_ID}"
-        iam: ENABLED
+      # Mount the mSigPortal subtree directly (confined to /msigportal) instead of
+      # through the uid-1000 access point. This lets the sync run as root so it can
+      # write into directories that were previously seeded (e.g. by DataSync) with a
+      # different owner. rootDirectory keeps the mount scoped to /msigportal, so the
+      # task cannot see or touch other applications' data on this shared filesystem.
+      rootDirectory: "/msigportal"
       transitEncryption: ENABLED
 containerDefinitions:
   - name: sync
-    image: public.ecr.aws/aws-cli/aws-cli:latest
+    image: public.ecr.aws/aws-cli/aws-cli:2.36.13
     essential: true
     entryPoint: ["/bin/sh", "-c"]
     command:
+      # Sync as root, then hand ownership of the whole mSigPortal tree back to the
+      # application's POSIX identity (uid/gid 1000) so the app can read/write it.
       - >-
         aws s3 sync "${DATA_S3_URI}" /data/Database/
+        && chown -R 1000:1000 /data
     mountPoints:
       - sourceVolume: data
         containerPath: "/data"

--- a/.github/aws/sync.yml
+++ b/.github/aws/sync.yml
@@ -16,18 +16,26 @@ volumes:
       # different owner. rootDirectory keeps the mount scoped to /msigportal, so the
       # task cannot see or touch other applications' data on this shared filesystem.
       rootDirectory: "/msigportal"
+      # Keep EFS IAM authorization enabled (defense-in-depth, consistent with the
+      # other task definitions in this repo). We drop only the accessPointId so the
+      # task mounts as root; iam stays ENABLED so the mount still presents the task
+      # role's credentials on any tier whose filesystem policy enforces IAM.
+      authorizationConfig:
+        iam: ENABLED
       transitEncryption: ENABLED
 containerDefinitions:
   - name: sync
-    image: public.ecr.aws/aws-cli/aws-cli:2.36.13
+    image: public.ecr.aws/aws-cli/aws-cli:latest
     essential: true
     entryPoint: ["/bin/sh", "-c"]
     command:
-      # Sync as root, then hand ownership of the whole mSigPortal tree back to the
-      # application's POSIX identity (uid/gid 1000) so the app can read/write it.
+      # Sync as root, then hand ownership of only the synced path (Database) back to
+      # the application's POSIX identity (uid/gid 1000) so the app can read/write it.
+      # Scoped to /data/Database — the only path this task writes — to avoid
+      # traversing unrelated (and potentially large) subtrees like genomes/ on every run.
       - >-
         aws s3 sync "${DATA_S3_URI}" /data/Database/
-        && chown -R 1000:1000 /data
+        && chown -R 1000:1000 /data/Database
     mountPoints:
       - sourceVolume: data
         containerPath: "/data"

--- a/.github/aws/sync.yml
+++ b/.github/aws/sync.yml
@@ -33,8 +33,11 @@ containerDefinitions:
       # the application's POSIX identity (uid/gid 1000) so the app can read/write it.
       # Scoped to /data/Database — the only path this task writes — to avoid
       # traversing unrelated (and potentially large) subtrees like genomes/ on every run.
+      # --exact-timestamps forces re-download when an object's timestamp differs even
+      # if its size is unchanged; regenerated plots can keep the same byte size, and
+      # without this flag `aws s3 sync` would silently leave the stale copy on EFS.
       - >-
-        aws s3 sync "${DATA_S3_URI}" /data/Database/
+        aws s3 sync "${DATA_S3_URI}" /data/Database/ --exact-timestamps
         && chown -R 1000:1000 /data/Database
     mountPoints:
       - sourceVolume: data


### PR DESCRIPTION
## Problem
The `Sync S3 to EFS` workflow (#96) failed on dev and qa. Every file failed with `[Errno 13] Permission denied` (0 successes), so new signatures (e.g. SBS22c) never reached EFS. Existing files still served because they were seeded earlier.

**Root cause:** the sync task mounts EFS through the uid-1000 access point, but `/msigportal` and its subdirs (`Database`, `Etiology`, `Profile`, `Profile_logo`, `genomes`) are owned by **uid/gid 65534** (from an earlier DataSync seed) with owner-only write. uid 1000 cannot create/overwrite files there.

## Fix (`.github/aws/sync.yml`)
- Mount the EFS subtree directly with `rootDirectory: /msigportal` (no access point) so the task runs as **root** and can write regardless of the 65534 ownership. The mount stays scoped to `/msigportal`, so the task cannot see or touch other apps on this shared filesystem.
- After `aws s3 sync`, run `chown -R 1000:1000 /data/Database` (the only path this task writes) to hand ownership back to the app's POSIX identity — self-healing on every run and across all tiers.
- Keep `authorizationConfig.iam: ENABLED` (drop only the access point ID) so the mount stays consistent with the repo's other task definitions.
- Keep the aws-cli image on `:latest` to match Phillip's original workflow and minimize the diff; keep `transitEncryption: ENABLED`.
- Use `aws s3 sync --exact-timestamps` so regenerated files that keep the same byte size (but changed content) are still re-pulled to EFS.

## Validation (dev)
Ran the rendered task def on `analysistools-dev`:
- Task exit code **0**
- **192 files** downloaded from S3
- **0 permission-denied errors**
- `chown` completed successfully