### PR TITLE
NCIATWP-10865: Promote S3-to-EFS sync permission fix (Solution B) to qa

### DIFF
--- a/.github/aws/sync.yml
+++ b/.github/aws/sync.yml
@@ -10,18 +10,24 @@ volumes:
   - name: data
     efsVolumeConfiguration:
       fileSystemId: "${EFS_FILESYSTEM_ID}"
-      authorizationConfig:
-        accessPointId: "${EFS_ACCESS_POINT_ID}"
-        iam: ENABLED
+      # Mount the mSigPortal subtree directly (confined to /msigportal) instead of
+      # through the uid-1000 access point. This lets the sync run as root so it can
+      # write into directories that were previously seeded (e.g. by DataSync) with a
+      # different owner. rootDirectory keeps the mount scoped to /msigportal, so the
+      # task cannot see or touch other applications' data on this shared filesystem.
+      rootDirectory: "/msigportal"
       transitEncryption: ENABLED
 containerDefinitions:
   - name: sync
-    image: public.ecr.aws/aws-cli/aws-cli:latest
+    image: public.ecr.aws/aws-cli/aws-cli:2.36.13
     essential: true
     entryPoint: ["/bin/sh", "-c"]
     command:
+      # Sync as root, then hand ownership of the whole mSigPortal tree back to the
+      # application's POSIX identity (uid/gid 1000) so the app can read/write it.
       - >-
         aws s3 sync "${DATA_S3_URI}" /data/Database/
+        && chown -R 1000:1000 /data
     mountPoints:
       - sourceVolume: data
         containerPath: "/data"

--- a/.github/aws/sync.yml
+++ b/.github/aws/sync.yml
@@ -16,18 +16,26 @@ volumes:
       # different owner. rootDirectory keeps the mount scoped to /msigportal, so the
       # task cannot see or touch other applications' data on this shared filesystem.
       rootDirectory: "/msigportal"
+      # Keep EFS IAM authorization enabled (defense-in-depth, consistent with the
+      # other task definitions in this repo). We drop only the accessPointId so the
+      # task mounts as root; iam stays ENABLED so the mount still presents the task
+      # role's credentials on any tier whose filesystem policy enforces IAM.
+      authorizationConfig:
+        iam: ENABLED
       transitEncryption: ENABLED
 containerDefinitions:
   - name: sync
-    image: public.ecr.aws/aws-cli/aws-cli:2.36.13
+    image: public.ecr.aws/aws-cli/aws-cli:latest
     essential: true
     entryPoint: ["/bin/sh", "-c"]
     command:
-      # Sync as root, then hand ownership of the whole mSigPortal tree back to the
-      # application's POSIX identity (uid/gid 1000) so the app can read/write it.
+      # Sync as root, then hand ownership of only the synced path (Database) back to
+      # the application's POSIX identity (uid/gid 1000) so the app can read/write it.
+      # Scoped to /data/Database — the only path this task writes — to avoid
+      # traversing unrelated (and potentially large) subtrees like genomes/ on every run.
       - >-
         aws s3 sync "${DATA_S3_URI}" /data/Database/
-        && chown -R 1000:1000 /data
+        && chown -R 1000:1000 /data/Database
     mountPoints:
       - sourceVolume: data
         containerPath: "/data"

--- a/.github/aws/sync.yml
+++ b/.github/aws/sync.yml
@@ -33,8 +33,11 @@ containerDefinitions:
       # the application's POSIX identity (uid/gid 1000) so the app can read/write it.
       # Scoped to /data/Database — the only path this task writes — to avoid
       # traversing unrelated (and potentially large) subtrees like genomes/ on every run.
+      # --exact-timestamps forces re-download when an object's timestamp differs even
+      # if its size is unchanged; regenerated plots can keep the same byte size, and
+      # without this flag `aws s3 sync` would silently leave the stale copy on EFS.
       - >-
-        aws s3 sync "${DATA_S3_URI}" /data/Database/
+        aws s3 sync "${DATA_S3_URI}" /data/Database/ --exact-timestamps
         && chown -R 1000:1000 /data/Database
     mountPoints:
       - sourceVolume: data


### PR DESCRIPTION
## Summary
Promotes the S3-to-EFS sync permission fix (Solution B) from `dev` to `qa`.

## Change
`.github/aws/sync.yml` — runs the sync Fargate task as root against a raw EFS mount (`rootDirectory: /msigportal`, access point dropped, `iam: ENABLED`, `transitEncryption: ENABLED`), then `chown -R 1000:1000 /data/Database`. Sync command uses `--exact-timestamps` to avoid the same-size skip on regenerated plots. Image stays on `:latest`.

## Why
qa EFS directories are owned by uid 65534 (old DataSync seed), which blocks the uid-1000 access-point sync (`[Errno 13] Permission denied`). Running as root bypasses this and `chown` hands ownership to the app's POSIX identity. Validated on dev (PR #100, exit 0, plots serving correctly).

## After merge
Dispatch **Sync S3 to EFS** workflow from the `qa` branch with tier=qa to fix ownership and pull the v3.6 plots.