### PR TITLE
NCIATWP-10865: Poll for ECS sync task completion (fix false-failed long syncs)

### DIFF
--- a/.github/workflows/sync-s3-efs.yml
+++ b/.github/workflows/sync-s3-efs.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   sync-s3-efs:
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     environment: ${{ inputs.tier }}
     env:
@@ -128,7 +128,20 @@ jobs:
       - name: Wait for sync task to complete
         run: |
           echo "Waiting for task to stop: $TASK_ARN"
-          aws ecs wait tasks-stopped --cluster "$ECS_CLUSTER" --tasks "$TASK_ARN"
+          # `aws ecs wait tasks-stopped` is hard-capped at 100 polls x 6s = 10 min and
+          # cannot be extended via the CLI, so large syncs (qa/prod) falsely report a
+          # failed job when the task legitimately runs longer. Poll instead, bounded by
+          # this job's timeout-minutes, and judge success only by the container exit code.
+          while true; do
+            STATUS=$(aws ecs describe-tasks \
+              --cluster "$ECS_CLUSTER" \
+              --tasks "$TASK_ARN" \
+              --query 'tasks[0].lastStatus' \
+              --output text)
+            echo "$(date -u +%H:%M:%S) task status: $STATUS"
+            [[ "$STATUS" == "STOPPED" ]] && break
+            sleep 15
+          done
 
           EXIT_CODE=$(aws ecs describe-tasks \
             --cluster "$ECS_CLUSTER" \

--- a/.github/workflows/sync-s3-efs.yml
+++ b/.github/workflows/sync-s3-efs.yml
@@ -132,6 +132,7 @@ jobs:
           # cannot be extended via the CLI, so large syncs (qa/prod) falsely report a
           # failed job when the task legitimately runs longer. Poll instead, bounded by
           # this job's timeout-minutes, and judge success only by the container exit code.
+          MISSING=0
           while true; do
             STATUS=$(aws ecs describe-tasks \
               --cluster "$ECS_CLUSTER" \
@@ -139,6 +140,19 @@ jobs:
               --query 'tasks[0].lastStatus' \
               --output text)
             echo "$(date -u +%H:%M:%S) task status: $STATUS"
+            # A missing task yields empty/None; tolerate a brief eventual-consistency
+            # window, then fail fast (with diagnostics) rather than spinning to timeout.
+            if [[ -z "$STATUS" || "$STATUS" == "None" ]]; then
+              MISSING=$((MISSING + 1))
+              if (( MISSING >= 3 )); then
+                echo "::error::describe-tasks returned no task for $TASK_ARN after $MISSING attempts — cannot determine sync status"
+                aws ecs describe-tasks --cluster "$ECS_CLUSTER" --tasks "$TASK_ARN" --output json || true
+                exit 1
+              fi
+              sleep 15
+              continue
+            fi
+            MISSING=0
             [[ "$STATUS" == "STOPPED" ]] && break
             sleep 15
           done


### PR DESCRIPTION
## Summary
Fixes the `Sync S3 to EFS` workflow reporting a **failed** job when a sync task legitimately runs longer than 10 minutes (e.g. qa/prod full-Database syncs).

## Root cause
The **Wait for sync task to complete** step used:
```bash
aws ecs wait tasks-stopped --cluster "$ECS_CLUSTER" --tasks "$TASK_ARN"
```
That built-in waiter is hard-capped at **100 polls × 6s = 10 minutes** and cannot be extended via the CLI. When the sync task runs longer, the waiter exits non-zero ("Max attempts exceeded"), and because the step runs under `bash -e` it dies **before** reading the container's real exit code — so a successful sync shows ❌.

Observed on the qa Solution B run (`30648111361`): task finished with **exit 0, zero permission errors** after ~18 min (~10 GiB transfer + `chown -R`), but the workflow was already marked failed at the 10-min mark.

## Change
- Replace the fixed waiter with a `describe-tasks` **poll loop** that waits until `lastStatus == STOPPED`, printing live status, then evaluates the existing `EXIT_CODE`/`STOP_REASON` check unchanged.
- Raise job `timeout-minutes` from **30 → 60** as the real safety bound for larger tiers.

## Testing
YAML validated. Behaviour verified conceptually against run `30648111361` (task reached STOPPED/exit 0 ~8 min after the old waiter had already failed the job).